### PR TITLE
Use `fedora-rawhide` as distro context for Rawhide

### DIFF
--- a/config.json
+++ b/config.json
@@ -109,12 +109,12 @@
             "compose": "Fedora-Rawhide",
             "tmt_context": {
                 "koji-build": {
-                    "distro": "fedora-38",
+                    "distro": "fedora-rawhide",
                     "arch": "x86_64",
                     "trigger": "build"
                 },
                 "fedora-dist-git": {
-                    "distro": "fedora-38",
+                    "distro": "fedora-rawhide",
                     "arch": "x86_64",
                     "trigger": "commit"
                 }


### PR DESCRIPTION
For some use cases it makes sense to enable specific plans or tests for Fedora Rawhide only. Currently this is not possible as users would need to update the config after each Fedora release.

Fix #48.