### PR TITLE
Revert "Only install the main artifact"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,15 +128,10 @@ pipeline {
             }
             steps {
                 script {
-                    def mainArtifactTaskId = getIdFromArtifactId(artifactId: artifactId)
                     def artifacts = []
                     getIdFromArtifactId(artifactId: artifactId, additionalArtifactIds: additionalArtifactIds).split(',').each { taskId ->
-                        def install = false
                         if (taskId) {
-                            if (taskId == mainArtifactTaskId) {
-                                install = true
-                            }
-                            artifacts.add([id: "${taskId}", type: "fedora-koji-build", install: install])
+                            artifacts.add([id: "${taskId}", type: "fedora-koji-build"])
                         }
                     }
 


### PR DESCRIPTION
We found out that for this to work well the installation plugin needs to first add and activate the artifacts repository, otherwise the other not installed builds are ignored.

We will get this back in 2024-04.1 TF release.

Crosslink:
https://issues.redhat.com/browse/TFT-2535

This reverts commit f34ca66a136289e4f451a50556585ab294744fa5.